### PR TITLE
增加对 WATCH 监视命令的支持

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -64,6 +64,10 @@ return PhpCsFixer\Config::create()
         'constant_case' => [
             'case' => 'lower',
         ],
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'end',
+        ],
         'class_attributes_separation' => true,
         'combine_consecutive_unsets' => true,
         'declare_strict_types' => true,

--- a/src/BaseRedis.php
+++ b/src/BaseRedis.php
@@ -17,7 +17,7 @@ class BaseRedis
     protected $connection;
 
     protected $multiOnGoing = false;
-    
+
     protected $isWatching = false;
 
     public function __construct($config = null, $poolName = 'default')
@@ -135,7 +135,7 @@ class BaseRedis
     {
         $this->pool->fill();
     }
-    
+
     public function watch($key)
     {
         if (! $this->multiOnGoing) {
@@ -153,7 +153,7 @@ class BaseRedis
 
         return $this;
     }
-    
+
     public function unwatch()
     {
         if (! $this->isWatching) {
@@ -204,13 +204,13 @@ class BaseRedis
         try {
             $result = $this->connection->exec();
         } catch (\RedisException $e) {
-            $this->isWatching   = false;
+            $this->isWatching = false;
             $this->multiOnGoing = false;
             $this->pool->close(null);
             throw $e;
         }
 
-        $this->isWatching   = false;
+        $this->isWatching = false;
         $this->multiOnGoing = false;
 
         $this->pool->close($this->connection);
@@ -227,13 +227,13 @@ class BaseRedis
         try {
             $result = $this->connection->discard();
         } catch (\RedisException $e) {
-            $this->isWatching   = false;
+            $this->isWatching = false;
             $this->multiOnGoing = false;
             $this->pool->close(null);
             throw $e;
         }
 
-        $this->isWatching   = false;
+        $this->isWatching = false;
         $this->multiOnGoing = false;
 
         $this->pool->close($this->connection);

--- a/src/BaseRedis.php
+++ b/src/BaseRedis.php
@@ -157,7 +157,7 @@ class BaseRedis
     public function unwatch()
     {
         if (! $this->isWatching) {
-            return;
+            return true;
         }
 
         try {


### PR DESCRIPTION
$redis = new BaseRedis();
$redis->watch("id");
$redis->multi()->set("id","abc")->exec();

如上：在多进程高并发情况下，使用 WATCH 命令时，会因并非同一个连接，而造成数据未按预期更新的情况发生。
为了保证事务 check-and-set （CAS）行为的可用性，保证使用同一个连接，特此增加对 WATCH 命令的支持。